### PR TITLE
Fix readme pattern to include subdirectories

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In a Github Action, download your project and run this action:
           debug: true
           directory: ./
           badge: ./output/badge.svg
-          patterns: '*.js'  # Patterns in the format of a '.gitignore' file, separated by pipes.
+          patterns: '**/*.js'  # Patterns in the format of a '.gitignore' file, separated by pipes.
           ignore: 'node_modules'
 ```
 


### PR DESCRIPTION
Thank you for the fixes you made to shadowmoose's version.

I found another issue which is that subdirectories are not included with the standard pattern `*.js`, `**/*.js` fixes it.

